### PR TITLE
井号的日文名称

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@ h2 span {
 	<td style>#</td>
 	<td style>hash, hash tag, pound, octothorpe</td>
 	<td style>井号</td>
-	<td style>ハッシュマーク、ポンド</td>
+	<td style>ハッシュタグ、番号記号</td>
 </tr>
 <tr>
 	<td style>$</td>


### PR DESCRIPTION
第一个应该作“ハッシュタグ”，是hash tag的日文读法。

ポンド对应于pound，因美国有一种标注重量的方式就是用#表示磅，这个很少用到。
# 更多地用作序号，如 人民路#1 表示 人民路1号，这在日文里称作「番号記号」。

（感谢[SHA Miao](https://github.com/shamiao)提示
