### PR TITLE
尖括号的日文说法

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,13 +302,13 @@ h2 span {
 	<td style>&lt;</td>
 	<td style>angle bracket, less than</td>
 	<td style>尖括号</td>
-	<td style>左アングルブラケット</td>
+	<td style>不等号(より小)、始め山括弧、左アングルブラケット</td>
 </tr>
 <tr>
   <td style>&gt;</td>
   <td style>angle bracket, more than, greater than</td>
   <td style>尖括号</td>
-	<td style>右アングルブラケット</td>
+	<td style>不等号(より大)、終わり山括弧、右アングルブラケット</td>
 </tr>
 <tr>
 	<td style>?</td>


### PR DESCRIPTION
左、右アングルブラケット和始め山括弧、終わり山括弧，严格来说，应该是 `〈 U+3008` 和 `〉U+3009`。`<和>`严格来说只是小于号、大于号。不过ASCII环境下也用这对不等号来代替山括弧，所以排后面吧。
